### PR TITLE
Unicode identifers

### DIFF
--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -10,7 +10,9 @@ Summary
 #######
 
 The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
-acknowledge Unicode as an afterthought, but there are large gaps in its support. This broad goals of this proposal areto:
+acknowledge Unicode as an afterthought, but there are large gaps in its support. This broad goals of this proposal are
+to:
+
 * most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
 * suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
 * provide a starting point of a wider discussion of the solution space.
@@ -20,26 +22,27 @@ Motivation
 ##########
 
 There are several problems with the way Haskell grapples with Unicode:
+
 * Outside of comments and strings, all letters allowed in a Haskell program must be either title case, uppercase or
-  lowercase letters. Most Unicode letters don't belong to any of these categories because their scripts don't
-  distinguish cases. Haskell completely disallows them at the lexical layer for no good reason.
-* Actually there is one moderately good reason to disallow uncased letters, but only at the beginning of an identifier:
-  the language fundamentally insists on classifying all identifiers as either capital or lowercase identifiers. As a
-  consequence, no word of Arabic, Chinese, and most other languages that use non-European scripts is allowed as a
-  Haskell identifier.
+lowercase letters. Most Unicode letters don't belong to any of these categories because their scripts don't
+distinguish cases. Haskell completely disallows them at the lexical layer for no good reason.
+* Actually there is one moderately good reason to disallow uncased letters, but only at the beginning of an
+identifier: the language fundamentally insists on classifying all identifiers as either capital or lowercase
+identifiers. As a consequence, no word of Arabic, Chinese, and most other languages that use non-European scripts is
+allowed as a Haskell identifier.
 * Another problem with the lexical identifier syntax is that it admits no accents and other modifier characters. This
-  excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing proper words for
-  Haskell identifiers.
+excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing proper words for
+Haskell identifiers.
 * In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and symbolic
-  operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
-  operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
-  proper representation for the operator is the single character ``≤``.
+operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
+operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
+proper representation for the operator is the single character ``≤``.
 * The same objection applies to alphanumeric symbols, such as mathematical (ℕ) alphanumerics. Even though these are
-  letters and they read as identifiers, they are not meant to be combined into words.
+letters and they read as identifiers, they are not meant to be combined into words.
 * The language syntax is restricted to ASCII characters, even when Unicode offers superior alternatives. `GHC's
-  UnicodeSyntax extension
-  <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
-  rectifies this to some extent, but it doesn't fill all the gaps.
+UnicodeSyntax extension
+<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
+rectifies this to some extent, but it doesn't fill all the gaps.
 
 This proposal attempts to resolve all these issues at once.
 
@@ -81,8 +84,7 @@ The present proposal changes the lexical syntax to the following:
 
 |   \ *varid*   → (*small* {*idCharacter*} | *mathSmall* {*modifier*}) \\ *reservedid*
 |   \ *conid*   → *large* {*idCharacter*} | *mathLarge* {*modifier*}
-|   \ *varsym*  → ((*ascSymbol* \\ :) {*ascSymbol* | *combining*} | *uniSymbol* {*combining*})
-|                 \\ ⟨*reservedop* | *dashes*⟩
+|   \ *varsym*  → ((*ascSymbol* \\ :) {*ascSymbol* | *combining*} | *uniSymbol* {*combining*}) \\ ⟨*reservedop* | *dashes*⟩
 |   \ *consym* → (: {*symbol* | *combining*}) \\ *reservedop*
 
 |   \ *idCharacter* → *letter* | *digit* | *modifier*
@@ -102,47 +104,48 @@ The present proposal changes the lexical syntax to the following:
 
 
 The changes can be explained and justified as follows:
-* The new lexical syntax permits all Unicode letters in identifiers. Any word in a script that supports no casing can be
-  made capital-case by preceding it by the character ˹ (02F9 - MODIFIER LETTER BEGIN HIGH TONE), or lowercase by
+
+* The new lexical syntax permits all Unicode letters in identifiers. Any word in a script that supports no casing can
+  be made capital-case by preceding it by the character ˹ (02F9 - MODIFIER LETTER BEGIN HIGH TONE), or lowercase by
   preceding it by the character ˻ (02FB - MODIFIER LETTER BEGIN LOW TONE).
 
 
   Example in Arabic:
-  العربية - "Arabic", a word of Arabic written in the Arabic script
-  ˹العربية - same word preceded by the *modifier letter begin high tone* character, marking it as capital
-  ˻العربية - same word with a *modifier letter begin low tone* the first character, marking it as lowercase
+  - العربية - "Arabic", a word of Arabic written in the Arabic script
+  - ˹العربية - same word preceded by the *modifier letter begin high tone* character, marking it as capital
+  - ˻العربية - same word with a *modifier letter begin low tone* the first character, marking it as lowercase
 
   Example in Devanagari:
-  भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
-  ˹भोजपुरी - same word preceded by the *modifier letter begin high tone* character, marking it as capital
-  ˻भोजपुरी - same word preceded by the *modifier letter begin low tone* character, marking it as lowercase
+  - भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
+  - ˹भोजपुरी - same word preceded by the *modifier letter begin high tone* character, marking it as capital
+  - ˻भोजपुरी - same word preceded by the *modifier letter begin low tone* character, marking it as lowercase
 
 * The new lexical syntax permits arbitrary combining characters and modifier letters in both identifiers and symbols.
 
   Examples:
 
-  f x x′ x″
-  f x x̊ x̉
-  résumé
+  - f x x′ x″
+  - f x x̊ x̉
+  - résumé
 
 * While a single symbol token can still contain a sequence of ASCII symbols, it can only contain a single non-ASCII
   symbol character and only at the beginning. The symbol character can be followed only by combining characters.
 
   Examples:
 
-  x≠-1
-  a⇒b = a∨¬b
-  APL and similar operator sequences
+  - x≠-1
+  - a⇒b = a∨¬b
+  - APL and similar operator sequences
 
 * Equivalently, every mathematical alphanumeric symbol represents a whole identifier, together with any following
   combining characters and modifier letters.
 
   Examples:
   
-  𝐈x   = x
-  𝐊𝑥𝑦  = 𝑥
-  𝐒𝑥𝑦𝑧 = 𝑥𝑧(𝑦𝑧)
-  𝐖 = 𝐒𝐒(𝐒𝐊)
+  - 𝐈x   = x
+  - 𝐊𝑥𝑦  = 𝑥
+  - 𝐒𝑥𝑦𝑧 = 𝑥𝑧(𝑦𝑧)
+  - 𝐖 = 𝐒𝐒(𝐒𝐊)
 
 * As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. This open the
   opportunity to add the identifier 𝛌 (U+1D6CC) to the list of reserved words, to prepare the ground for a future
@@ -178,9 +181,9 @@ The proposal is limited to the lexical layer of the language. A more ambitious a
 false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Idris have done that with no obvious
 adverse consequences.
 
-The Unicode Consortium itself suggests a <Default Identifier
-Syntax>`https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax`_ that takes into consideration many
-more problems than considered here, but is also much more complex that the proposed syntax.
+The Unicode Consortium itself suggests a `Default Identifier
+Syntax<https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax>`_ that takes into consideration
+many more problems than considered here, but is also much more complex that the proposed syntax.
 
 ####################
 Unresolved questions
@@ -188,6 +191,7 @@ Unresolved questions
 
 It is unclear if the *specialSmall* / *specialLarge* hack is enough to enable the use of non-European scripts. The
 proper answer can be given only by a poll of Haskell users. The set of possible answers would include:
+
 * I only ever write English identifiers in Haskell.
 * I only write identifiers using Latin or Cyrillic scripts with no diacritical modifiers.
 * I wish I could write Haskell with identifiers in my native language,

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -102,6 +102,9 @@ The present proposal changes the lexical syntax to the following:
 |   \ *specialLarge* → Unicode character 02FA (˻)
 
 
+Explanations
+------------
+
 The changes can be explained and justified as follows:
 
 * The new lexical syntax permits all Unicode letters in identifiers. Any word in a script that supports no casing can

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -18,18 +18,22 @@ Motivation
 ##########
 
 There are several problems with the way Haskell grapples with Unicode:
-* The language fundamentally insists on classifying all identifiers as either capital or lowercase identifiers at the
-  lexical layer, but many Unicode scripts don't even recognize the concept. No word of Arabic, Chinese, and most other
-  languages that use non-European scripts cannot be Haskell identifiers as a consequence.
+* Outside of comments and strings, all letters allowed in a Haskell program must be either title case, uppercase or
+  lowercase letters. Most Unicode letters don't belong to any of these categories because their scripts don't
+  distinguish cases. Haskell completely disallows them at the lexical layer for no good reason.
+* Actually there is one moderately good reason to disallow uncased letters, but only at the beginning of an identifier:
+  the language fundamentally insists on classifying all identifiers as either capital or lowercase identifiers. As a
+  consequence, no word of Arabic, Chinese, and most other languages that use non-European scripts is allowed as a
+  Haskell identifier.
 * Another problem with the lexical identifier syntax is that it admits no accents and other modifier characters. This
   excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing proper words for
   Haskell identifiers.
 * In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and symbolic
   operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
   operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
-  proper representation for the operation is the single character ``≤``.
-* The same objection appplies to alphanumeric symbols, such as enclosed (Ⓐ) and mathematical (ℕ) alphanumerics. Even
-  though these are letters and they read as identifiers, they are not meant to be combined into words.
+  proper representation for the operator is the single character ``≤``.
+* The same objection applies to alphanumeric symbols, such as mathematical (ℕ) alphanumerics. Even though these are
+  letters and they read as identifiers, they are not meant to be combined into words.
 * The language syntax is restricted to ASCII characters, even when Unicode offers superior alternatives. `GHC's
   UnicodeSyntax extension
   <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
@@ -79,63 +83,68 @@ The present proposal changes the lexical syntax to the following:
 |                 \\ ⟨*reservedop* | *dashes*⟩
 |   \ *consym* → (: {*symbol* | *combining*}) \\ *reservedop*
 
-|   \ *idCharacter* → *small* | *large* | *uncased* | *modifier*
-|   \ *modifier* → *digit* | *combining* | '
-|   \ *small*    → *ascSmall* | *uniSmall* \\ *mathSmall* | _ | *uncased* *combiningBelow*
-|   \ *large*    → *ascLarge* | *uniLarge* \\ *mathLarge* | *uncased* *combiningAbove*
-|   \ *uncased* → any Unicode letter with no case
+|   \ *idCharacter* → *letter* | *digit* | *modifier*
+|   \ *modifier* → *modifierLetter* | *combining* | '
+|   \ *small*    → *ascSmall* | *uniSmall* \\ *mathSmall* | _ | *specialSmall*
+|   \ *large*    → *ascLarge* | *uniLarge* \\ *mathLarge* | *specialLarge*
+|   \ *letter* → any Unicode letter
 
 |   \ *mathSmall* → any Unicode lowercase mathematical letter (i.e., with the derived property ``Math``)
-|   \ *mathLarge* → any Unicode capital mathematical letter
+|   \ *mathLarge* → any Unicode uppercase mathematical letter
 |   \ *uniSymbol* → any Unicode symbol or punctuation
 
-|   \ *combining* → any Unicode combining character
-|   \ *combiningBelow* → any Unicode combining character below the base character
-|   \ *combiningAbove* → any Unicode combining character above the base character
+|   \ *modifierLetter* -> any Unicode modifier letter (with general class ``Lm``) 
+|   \ *combining* → any Unicode combining character (with general class ``Mn``, ``Mc``, or ``Me``) 
+|   \ *specialSmall* → Unicode character 02F9 (˹)
+|   \ *specialLarge* → Unicode character 02FA (˻)
 
 
 The changes can be explained and justified as follows:
-* The new lexical syntax permits arbitrary combining characters in both identifiers and symbols.
-* The purpose of the *combiningBelow* and *combiningAbove* characters is to fake the case distinction. An identifier
-  that starts with a non-cased letter must have one of these combining characters immediately following the letter.
+* The new lexical syntax permits all Unicode letters in identifiers. Any word in a script that supports no casing can be
+  made capital-case by preceding it by the character ˹ (02F9 - MODIFIER LETTER BEGIN HIGH TONE), or lowercase by
+  preceding it by the character ˻ (02FB - MODIFIER LETTER BEGIN LOW TONE).
+
+
+  Example in Arabic:
+  العربية - "Arabic", a word of Arabic written in the Arabic script
+  ˹العربية - same word preceded by the *modifier letter begin high tone* character, marking it as capital
+  ˻العربية - same word with a *modifier letter begin low tone* the first character, marking it as lowercase
+
+  Example in Devanagari:
+  भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
+  ˹भोजपुरी - same word preceded by the *modifier letter begin high tone* character, marking it as capital
+  ˻भोजपुरी - same word preceded by the *modifier letter begin low tone* character, marking it as lowercase
+
+* The new lexical syntax permits arbitrary combining characters and modifier letters in both identifiers and symbols.
+
+  Examples:
+
+  f x x′ x″
+  f x x̊ x̉
+  résumé
+
 * While a single symbol token can still contain a sequence of ASCII symbols, it can only contain a single non-ASCII
   symbol character and only at the beginning. The symbol character can be followed only by combining characters.
+
+  Examples:
+
+  x≠-1
+  a⇒b = a∨¬b
+  APL operator strings like X[⍋X+.≠' ';]
+
 * Equivalently, every mathematical alphanumeric symbol represents a whole identifier, together with any following
-  combining characters and digits.
-* As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. The identifier 𝛌
-  (U+1D6CC) should be added to the list of reserved words, to prepare the ground for a future proposal that makes it a
-  valid alternative for the backslash.
+  combining characters and modifier letters.
 
-Examples
-########
+  Examples:
+  
+  𝐈x   = x
+  𝐊𝑥𝑦  = 𝑥
+  𝐒𝑥𝑦𝑧 = 𝑥𝑧(𝑦𝑧)
+  𝐖 = 𝐒𝐒(𝐒𝐊)
 
-Arabic
-العربية - "Arabic", a word of Arabic written in the Arabic script
-ا̊لعربية - same word with a *combining ring above* the first character, marking it as capital
-ا̥لعربية - same word with a *combining ring below* the first character, marking it as capital
-
-Devanagari
-भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
-भो͘जपुरी - same word with a *combining dot above right* of the first character, marking it as capital
-भो᪶जपुरी - same word with a *combining wiggly line below* of the first character, marking it as lowercase
-
-ⁱfoo
-ⁿbarˆ
-
-𝚺
-sin𝛼
-x⃗
-x′ʹ
-
-
-𝐈x   = x
-𝐊𝑥𝑦  = 𝑥
-𝐒𝑥𝑦𝑧 = 𝑥𝑧(𝑦𝑧)
-
-𝐖 = 𝐒𝐒(𝐒𝐊)
-
-a⇒b = a∨¬b
-
+* As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. This open the
+  opportunity to add the identifier 𝛌 (U+1D6CC) to the list of reserved words, to prepare the ground for a future
+  proposal that makes it a valid alternative for the backslash.
 
 #########
 Drawbacks
@@ -152,17 +161,20 @@ existing libraries that can help with that.
 
 While the proposal is rather ambitious in some ways, it changes only the lexical syntax of Haskell. As a consequence,
 the unfortunate distinction between the capital and lowercase identifiers imposed by the higher-level syntax is still in
-place. Scripts of non-European origin that don't have any case distinctions can now be used with the *combiningBelow*
-and *combiningAbove* characters, but this is only a fig leaf.
+place. Scripts of non-European origin that don't have any case distinctions can now be used with the *specialSmall*
+and *specialLarge* characters, but this is only a fig leaf.
 
 
 ############
 Alternatives
 ############
 
-As noted above, the proposal is limited to the lexical layer of the language. A more ambitious alternative would be to
-eliminate the false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Idris have done that with no
-obvious adverse consequences.
+The present proposal combines several modifications to Haskell's lexical syntax of identifiers and symbols. If some of
+the parts are deemed better than the others, they can be implemented alone.
+
+The proposal is limited to the lexical layer of the language. A more ambitious alternative would be to eliminate the
+false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Idris have done that with no obvious
+adverse consequences.
 
 The Unicode Consortium itself suggests a <Default Identifier
 Syntax>`https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax`_ that takes into consideration many
@@ -172,7 +184,7 @@ more problems than considered here, but is also much more complex that the propo
 Unresolved questions
 ####################
 
-It is unclear if the *combiningBelow* / *combiningAbove* hack is enough to enable the use of non-European scripts. The
+It is unclear if the *specialSmall* / *specialLarge* hack is enough to enable the use of non-European scripts. The
 proper answer can be given only by a poll of Haskell users. The set of possible answers would include:
 * I only ever write English identifiers in Haskell.
 * I only write identifiers using Latin or Cyrillic scripts with no diacritical modifiers.

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -11,38 +11,36 @@ Summary
 
 The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
 acknowledge Unicode as an afterthought, but there are large gaps in its support. This broad goals of this proposal are
-to:
-
-* most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
-* suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
-* provide a starting point of a wider discussion of the solution space.
+to: 
+  * most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
+  * suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
+  * provide a starting point of a wider discussion of the solution space.
 
 ##########
 Motivation
 ##########
 
 There are several problems with the way Haskell grapples with Unicode:
-
-* Outside of comments and strings, all letters allowed in a Haskell program must be either title case, uppercase or
-lowercase letters. Most Unicode letters don't belong to any of these categories because their scripts don't
-distinguish cases. Haskell completely disallows them at the lexical layer for no good reason.
-* Actually there is one moderately good reason to disallow uncased letters, but only at the beginning of an
-identifier: the language fundamentally insists on classifying all identifiers as either capital or lowercase
-identifiers. As a consequence, no word of Arabic, Chinese, and most other languages that use non-European scripts is
-allowed as a Haskell identifier.
-* Another problem with the lexical identifier syntax is that it admits no accents and other modifier characters. This
-excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing proper words for
-Haskell identifiers.
-* In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and symbolic
-operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
-operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
-proper representation for the operator is the single character ``≤``.
-* The same objection applies to alphanumeric symbols, such as mathematical (ℕ) alphanumerics. Even though these are
-letters and they read as identifiers, they are not meant to be combined into words.
-* The language syntax is restricted to ASCII characters, even when Unicode offers superior alternatives. `GHC's
-UnicodeSyntax extension
-<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
-rectifies this to some extent, but it doesn't fill all the gaps.
+  * Outside of comments and strings, all letters allowed in a Haskell program must be either title case, uppercase or
+    lowercase letters. Most Unicode letters don't belong to any of these categories because their scripts don't
+    distinguish cases. Haskell completely disallows them at the lexical layer for no good reason.
+  * Actually there is one moderately good reason to disallow uncased letters, but only at the beginning of an
+    identifier: the language fundamentally insists on classifying all identifiers as either capital or lowercase
+    identifiers. As a consequence, no word of Arabic, Chinese, and most other languages that use non-European scripts
+    is allowed as a Haskell identifier.
+  * Another problem with the lexical identifier syntax is that it admits no accents and other modifier
+    characters. This excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing
+    proper words for Haskell identifiers.
+  * In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and
+    symbolic operators. But symbol characters are not meant to be syntactically combined with each other. The
+    multi-character operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII
+    character set; the proper representation for the operator is the single character ``≤``.
+  * The same objection applies to alphanumeric symbols, such as mathematical (ℕ) alphanumerics. Even though these are
+    letters and they read as identifiers, they are not meant to be combined into words.
+  * The language syntax is restricted to ASCII characters, even when Unicode offers superior alternatives. `GHC's
+    UnicodeSyntax extension
+    <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
+    rectifies this to some extent, but it doesn't fill all the gaps.
 
 This proposal attempts to resolve all these issues at once.
 
@@ -54,7 +52,7 @@ The existing lexical syntax of Haskell variable identifiers and symbols is speci
 
 |   \ *varid*  → (*small* {*idCharacter*}) \\ *reservedid*
 |   \ *conid*  → *large* {*idCharacter*}
-|   \ *varsym* → ((*symbol* \\ :) {*symbol*}) \\ ⟨*reservedop* | *dashes*⟩
+|   \ *varsym* → ((*symbol* \\ :) {*symbol*}) \\ (*reservedop* | *dashes*)
 |   \ *consym* → (: {*symbol*}) \\ *reservedop*
 
 |   \ *idCharacter* → *small* | *large* | *digit* | '
@@ -71,7 +69,7 @@ The existing lexical syntax of Haskell variable identifiers and symbols is speci
 |   \ *ascDigit* → 0 | 1 | … | 9
 |   \ *uniDigit* → any Unicode decimal digit
 
-|   \ *symbol*    → *ascSymbol* | *uniSymbol* \\ ⟨*special* | _ | " | '⟩
+|   \ *symbol*    → *ascSymbol* | *uniSymbol* \\ (*special* | _ | " | ')
 |   \ *ascSymbol* → ! | # | $ | % | & | ⋆ | + | . | / | < | = | > | ? | @ | \\ | ^ | | | - | ~ | :
 |   \ *uniSymbol* → any Unicode symbol or punctuation
 |   \ *special*   → ( | ) | , | ; | [ | ] | ` | { | }
@@ -84,7 +82,7 @@ The present proposal changes the lexical syntax to the following:
 
 |   \ *varid*   → (*small* {*idCharacter*} | *mathSmall* {*modifier*}) \\ *reservedid*
 |   \ *conid*   → *large* {*idCharacter*} | *mathLarge* {*modifier*}
-|   \ *varsym*  → ((*ascSymbol* \\ :) {*ascSymbol* | *combining*} | *uniSymbol* {*combining*}) \\ ⟨*reservedop* | *dashes*⟩
+|   \ *varsym*  → ((*ascSymbol* \\ :) {*ascSymbol* | *combining*} | *uniSymbol* {*combining*}) \\ (*reservedop* | *dashes*)
 |   \ *consym* → (: {*symbol* | *combining*}) \\ *reservedop*
 
 |   \ *idCharacter* → *letter* | *digit* | *modifier*
@@ -195,6 +193,7 @@ proper answer can be given only by a poll of Haskell users. The set of possible 
 * I only ever write English identifiers in Haskell.
 * I only write identifiers using Latin or Cyrillic scripts with no diacritical modifiers.
 * I wish I could write Haskell with identifiers in my native language,
+
   * and with this extension I would
   * the proposed extension is insufficient, but a step in the right direction
   * but the proposed extension is useless.

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -1,0 +1,137 @@
+- Feature Name: Unicode Identifiers
+- Start Date: 2017-11-26
+- RFC PR: Leave this empty, filled on proposal accept
+- Haskell Report Issue: Leave this empty, filled on proposal accept
+
+
+
+#######
+Summary
+#######
+
+The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
+acknowledge Unicode as an afterthought, but there are large gaps in its support. This proposal aims to rectify this
+while retaining backward compatibility with the existing ASCII-only Haskell code.
+
+##########
+Motivation
+##########
+
+There are several problems with the way Haskell grapples with Unicode:
+* The language fundamentally insists on classifying all identifiers as either capital or lowercase identifiers at the
+  lexical layer, but many Unicode scripts don't even recognize the concept. As a consequence, words of languages
+  that don't use European scripts cannot be Haskell identifiers.
+* Another problem with the lexical identifier syntax is that it admits no accents and other modifier characters. This
+  excludes yet another class of languages, such as modern Greek, from providing words for Haskell identifiers.
+* In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and symbolic
+  operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
+  operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
+  proper representation for the operation is the single character ``≤``.
+* The same objection appplies to alphanumeric symbols, such as enclosed (Ⓐ) and mathematical (ℕ) alphanumerics. Even
+  though these are letters and they read as identifiers, they are not meant to be combined into words.
+* The language syntax is restricted to ASCII characters, even when Unicode offers superior alternatives. `GHC's
+  UnicodeSyntax extension
+  <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#ghc-flag--XUnicodeSyntax>`_
+  rectifies this to some extent, but it doesn't fill all the gaps.
+
+This proposal attempts to resolve all these issues at once.
+
+###############
+Detailed design
+###############
+
+The existing lexical syntax of Haskell variable identifiers and symbols is specified as
+
+|   \ *varid*  → (*small* {*idCharacter*}) \\ *reservedid*
+|   \ *conid*  → *large* {*idCharacter*}
+|   \ *varsym* → ((*symbol* \\ :) {*symbol*}) \\ ⟨*reservedop* | *dashes*⟩
+|   \ *consym* → (: {*symbol*}) \\ *reservedop*
+
+|   \ *idCharacter* → *small* | *large* | *digit* | '
+|   \ *small*    → *ascSmall* | *uniSmall* | _
+|   \ *large*    → *ascLarge* | *uniLarge*
+
+|   \ *ascSmall* → a | b | … | z
+|   \ *uniSmall* → any Unicode lowercase letter
+ 
+|   \ *ascLarge* → A | B | … | Z
+|   \ *uniLarge* → any uppercase or titlecase Unicode letter
+
+|   \ *digit*    → *ascDigit* | *uniDigit*
+|   \ *ascDigit* → 0 | 1 | … | 9
+|   \ *uniDigit* → any Unicode decimal digit
+
+|   \ *symbol*    → *ascSymbol* | *uniSymbol* \\ ⟨*special* | _ | " | '⟩
+|   \ *ascSymbol* → ! | # | $ | % | & | ⋆ | + | . | / | < | = | > | ? | @ | \\ | ^ | | | - | ~ | :
+|   \ *uniSymbol* → any Unicode symbol or punctuation
+|   \ *special*   → ( | ) | , | ; | [ | ] | ` | { | }
+
+
+New lexical syntax of identifiers and symbols
+#############################################
+
+The present proposal changes the lexical syntax to the following:
+
+|   \ *varid*   → (*small* {*idCharacter*} | *mathSmall* {*modifier*}) \\ *reservedid*
+|   \ *conid*   → *large* {*idCharacter*} | *mathLarge* {*modifier*}
+|   \ *varsym*  → ((*ascSymbol* \\ :) {*ascSymbol* | *combining*} | *uniSymbol* {*combining*})
+|                 \\ ⟨*reservedop* | *dashes*⟩
+|   \ *consym* → (: {*symbol* | *combining*}) \\ *reservedop*
+
+|   \ *idCharacter* → *small* | *large* | *uncased* | *modifier*
+|   \ *modifier* → *digit* | *combining* | '
+|   \ *small*    → *ascSmall* | *uniSmall* \\ *mathSmall* | _ | *uncased* *combiningBelow*
+|   \ *large*    → *ascLarge* | *uniLarge* \\ *mathLarge* | *uncased* *combiningAbove*
+|   \ *uncased* → any Unicode letter with no case
+
+|   \ *mathSmall* → any Unicode lowercase mathematical letter (i.e., with the derived property ``Math``)
+|   \ *mathLarge* → any Unicode capital mathematical letter
+|   \ *uniSymbol* → any Unicode symbol or punctuation
+
+|   \ *combining* → any Unicode combining character
+|   \ *combiningBelow* → any Unicode combining character below the base character
+|   \ *combiningAbove* → any Unicode combining character above the base character
+
+
+The changes can be explained and justified as follows:
+* The new lexical syntax permits arbitrary combining characters in both identifiers and symbols.
+* The purpose of the *combiningBelow* and *combiningAbove* characters is to fake the case distinction. An identifier
+  that starts with a non-cased letter must have one of these combining characters immediately following the letter.
+* While a single symbol token can still contain a sequence of ASCII symbols, it can only contain a single non-ASCII
+  symbol character and only at the beginning. The symbol character can be followed only by combining characters.
+* Equivalently, every mathematical alphanumeric symbol represents a whole identifier, together with any following
+  combining characters and digits.
+* As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. 
+
+
+#########
+Drawbacks
+#########
+
+This proposal breaks the compatibility with Haskell 2010, but few programs will be affected. The most significant
+compatibility break would probably be to programs that define operators as sequences of non-ASCII symbol
+characters. These would now be considered multiple symbol tokens.
+
+If implemented whole, the proposal would also make the lexical syntax of the language incrementally more complex and
+harder to implement. The proposed syntax can still be expressed using regular expressions, so most lexers should have no
+trouble with it. The main difficulty may be in correctly recognizing various Unicode character classes, but there are
+existing libraries that can help with that.
+
+While the proposal is rather ambitious in some ways, it changes only the lexical syntax of Haskell. As a consequence,
+the unfortunate distinction between the capital and lowercase identifiers imposed by the higher-level syntax is still in
+place. Scripts of non-European origin that don't have any case distinctions can now be used with the *combiningBelow*
+and *combiningAbove* characters, but this is only a fig leaf.
+
+
+############
+Alternatives
+############
+
+As noted above, the proposal is limited to the lexical layer of the language. A more ambitious alternative would be to
+eliminate the false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Idris have done that with no
+obvious adverse consequences.
+
+
+####################
+Unresolved questions
+####################

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -11,7 +11,7 @@ Summary
 
 The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
 acknowledge Unicode as an afterthought, but there are large gaps in its support. This proposal aims to rectify this
-while retaining backward compatibility with the existing ASCII-only Haskell code.
+while retaining backward compatibility with all existing ASCII-only Haskell code.
 
 ##########
 Motivation
@@ -19,10 +19,11 @@ Motivation
 
 There are several problems with the way Haskell grapples with Unicode:
 * The language fundamentally insists on classifying all identifiers as either capital or lowercase identifiers at the
-  lexical layer, but many Unicode scripts don't even recognize the concept. As a consequence, words of languages
-  that don't use European scripts cannot be Haskell identifiers.
+  lexical layer, but many Unicode scripts don't even recognize the concept. No word of Arabic, Chinese, and most other
+  languages that use non-European scripts cannot be Haskell identifiers as a consequence.
 * Another problem with the lexical identifier syntax is that it admits no accents and other modifier characters. This
-  excludes yet another class of languages, such as modern Greek, from providing words for Haskell identifiers.
+  excludes or deters yet another class of languages, such as modern Greek or Navajo, from providing proper words for
+  Haskell identifiers.
 * In keeping with other programming languages, Haskell uses the “maximal munch” rule for both identifers and symbolic
   operators. But symbol characters are not meant to be syntactically combined with each other. The multi-character
   operators like ``<=`` are a legacy that exists only due to the small size of the legacy ASCII character set; the
@@ -101,7 +102,39 @@ The changes can be explained and justified as follows:
   symbol character and only at the beginning. The symbol character can be followed only by combining characters.
 * Equivalently, every mathematical alphanumeric symbol represents a whole identifier, together with any following
   combining characters and digits.
-* As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. 
+* As a consequence, the sequence of characters ``𝛌x.x`` would be tokenized into four distinct tokens. The identifier 𝛌
+  (U+1D6CC) should be added to the list of reserved words, to prepare the ground for a future proposal that makes it a
+  valid alternative for the backslash.
+
+Examples
+########
+
+Arabic
+العربية - "Arabic", a word of Arabic written in the Arabic script
+ا̊لعربية - same word with a *combining ring above* the first character, marking it as capital
+ا̥لعربية - same word with a *combining ring below* the first character, marking it as capital
+
+Devanagari
+भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
+भो͘जपुरी - same word with a *combining dot above right* of the first character, marking it as capital
+भो᪶जपुरी - same word with a *combining wiggly line below* of the first character, marking it as lowercase
+
+ⁱfoo
+ⁿbarˆ
+
+𝚺
+sin𝛼
+x⃗
+x′ʹ
+
+
+𝐈x   = x
+𝐊𝑥𝑦  = 𝑥
+𝐒𝑥𝑦𝑧 = 𝑥𝑧(𝑦𝑧)
+
+𝐖 = 𝐒𝐒(𝐒𝐊)
+
+a⇒b = a∨¬b
 
 
 #########
@@ -131,7 +164,22 @@ As noted above, the proposal is limited to the lexical layer of the language. A 
 eliminate the false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Idris have done that with no
 obvious adverse consequences.
 
+The Unicode Consortium itself suggests a <Default Identifier
+Syntax>`https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax`_ that takes into consideration many
+more problems than considered here, but is also much more complex that the proposed syntax.
 
 ####################
 Unresolved questions
 ####################
+
+It is unclear if the *combiningBelow* / *combiningAbove* hack is enough to enable the use of non-European scripts. The
+proper answer can be given only by a poll of Haskell users. The set of possible answers would include:
+* I only ever write English identifiers in Haskell.
+* I only write identifiers using Latin or Cyrillic scripts with no diacritical modifiers.
+* I wish I could write Haskell with identifiers in my native language,
+  * and with this extension I would
+  * the proposed extension is insufficient, but a step in the right direction
+  * but the proposed extension is useless.
+
+If this proposal were adopted, the next step would be to move up a layer to the language syntax. Most importantly, the
+newly available mathematical lambda keyword should be allowed instead of its sad backslash immitation.

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -10,8 +10,10 @@ Summary
 #######
 
 The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
-acknowledge Unicode as an afterthought, but there are large gaps in its support. This proposal aims to rectify this
-while retaining backward compatibility with all existing ASCII-only Haskell code.
+acknowledge Unicode as an afterthought, but there are large gaps in its support. This broad goals of this proposal areto:
+* most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
+* suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
+* provide a starting point of a wider discussion of the solution space.
 
 ##########
 Motivation
@@ -130,7 +132,7 @@ The changes can be explained and justified as follows:
 
   x≠-1
   a⇒b = a∨¬b
-  APL operator strings like X[⍋X+.≠' ';]
+  APL and similar operator sequences
 
 * Equivalently, every mathematical alphanumeric symbol represents a whole identifier, together with any following
   combining characters and modifier letters.

--- a/0000-unicode-identifers.rst
+++ b/0000-unicode-identifers.rst
@@ -11,10 +11,11 @@ Summary
 
 The lexical syntax of Haskell'98 has been designed primarily for the ASCII character set. The language report does
 acknowledge Unicode as an afterthought, but there are large gaps in its support. This broad goals of this proposal are
-to: 
-  * most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
-  * suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
-  * provide a starting point of a wider discussion of the solution space.
+to:
+
+* most importantly, highlight some longstanding problems with Haskell's treatment of Unicode,
+* suggest a package of remedies that retains backward compatibility with all existing ASCII-only Haskell code, and
+* provide a starting point of a wider discussion of the solution space.
 
 ##########
 Motivation
@@ -109,11 +110,13 @@ The changes can be explained and justified as follows:
 
 
   Example in Arabic:
+  
   - العربية - "Arabic", a word of Arabic written in the Arabic script
   - ˹العربية - same word preceded by the *modifier letter begin high tone* character, marking it as capital
   - ˻العربية - same word with a *modifier letter begin low tone* the first character, marking it as lowercase
 
   Example in Devanagari:
+  
   - भोजपुरी - "Bhojpuri", a word of the Bhojpuri language written in the Devanagari script
   - ˹भोजपुरी - same word preceded by the *modifier letter begin high tone* character, marking it as capital
   - ˻भोजपुरी - same word preceded by the *modifier letter begin low tone* character, marking it as lowercase
@@ -180,7 +183,7 @@ false uppercase/lowercase dichotomy from the syntax altogether. Both Agda and Id
 adverse consequences.
 
 The Unicode Consortium itself suggests a `Default Identifier
-Syntax<https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax>`_ that takes into consideration
+Syntax <https://www.unicode.org/reports/tr31/tr31-10.html#Default_Identifier_Syntax>`_ that takes into consideration
 many more problems than considered here, but is also much more complex that the proposed syntax.
 
 ####################


### PR DESCRIPTION
This PR, among other things, is a generalized replacement for the abandoned [Lambda the Ultimate Reserved Keyword](https://github.com/haskell/rfcs/pull/19) PR.

[Rendered Proposal](https://github.com/blamario/rfcs/blob/unicode-identifers/0000-unicode-identifers.rst)
